### PR TITLE
Changing snap.js dependancy to latest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "README.md"
   ],
   "dependencies": {
-    "snapjs": "1.x"
+    "snapjs": "latest"
   }
 }


### PR DESCRIPTION
The 1.x tag no longer exists on the Snap.js repo. Change dependancy to latest
